### PR TITLE
Remove default transparency when adding WMS layers.

### DIFF
--- a/geopunt4QgisDataCatalog.py
+++ b/geopunt4QgisDataCatalog.py
@@ -262,7 +262,6 @@ class geopunt4QgisDataCatalog(QtGui.QDialog):
         try:
             rlayer = QgsRasterLayer(wmsUrl, layerTitle, 'wms') 
             if rlayer.isValid():
-               rlayer.renderer().setOpacity(0.8)
                QgsMapLayerRegistry.instance().addMapLayer(rlayer)
             else:  
                 self.bar.pushMessage("Error", 


### PR DESCRIPTION
WMS layers are styled serverside and are meant to be interpreted this way.

Styling, including the (lack of) transparency, is done on the server and adding a default transparency of 20% to all layers breaks the unified user interpretation of WMS layers. Users can always adjust the transparency of the added layer afterwards if they want to.

Furthermore it currently highlights a rendering issue in QGis which breaks rendering of layers with transparency != 0 that are already (semi-)transparent serverside. This causes some layers (f.ex. "Verziltingskaart grondwater") to look wrong by default. Cfr. QGis issue http://hub.qgis.org/issues/12300
